### PR TITLE
set text color for bing maps, closes #24

### DIFF
--- a/osm-org-greasemonkey.user.js
+++ b/osm-org-greasemonkey.user.js
@@ -259,7 +259,7 @@ function modifyContent() {
       createOrUpdate("GM-KARTA", navbar_content, thisUrl, "<strong style=\"color:#0C1D2E\">Karta</strong><span style=\"color:#635BFF\">View</span>", "btn btn-outline-primary");
       // Bing Aerial
       thisUrl = "https://www.bing.com/maps?cp=" + OsmMap.lat + "%7E" + OsmMap.lon + "&lvl=" + (parseInt(OsmMap.zoom)+1).toString() + "&style=a";
-      createOrUpdate("GM-BING", navbar_content, thisUrl, "BingMaps", "btn btn-outline-primary", "BingMaps Aerial Layer");
+      createOrUpdate("GM-BING", navbar_content, thisUrl, "<span style=\"color:#737373\">Bing Maps</span>", "btn btn-outline-primary", "BingMaps Aerial Layer");
       // Discourse Community
       thisUrl = "https://community.openstreetmap.org/";
       createOrUpdate("GM-COMMU", navbar_content, thisUrl, "<span style=\"color:\">OSM</span> <strong style=\"color:\">Community</strong>", "btn btn-outline-primary", "OpenStreetMap Community Discourse");


### PR DESCRIPTION
According to https://www.microsoft.com/en-us/maps/brand-guidelines since the logo is an image, we can't link to it.
The Segoe font-family does not exist for me, in firefox, apparently